### PR TITLE
fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# [Visit Site](joemmalatesta.com)
+# [Visit joemmalatesta.com](https://www.joemmalatesta.com/)
 
 ## Made with Astro, svelte, and tailwind, and deployed using vercel


### PR DESCRIPTION
Without `http(s)`, markdown links are relative to Github.com